### PR TITLE
chore: bump compatibility to Foundry v14 and TAH Core v2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ Token Action HUD WFRP4e is a repositionable HUD of actions for a selected token 
 **IMPORTANT** — Token Action HUD WFRP 4e requires the [Token Action HUD Core](https://foundryvtt.com/packages/token-action-hud-core) module to be installed.
 
 **Required Core version:**
-- TAH WFRP4e v3.0.0 and newer: Core v2.0
+- TAH WFRP4e v9.5.0 and newer: Core v2.1
+- TAH WFRP4e v3.0.0 - v9.4.1: Core v2.0
 - TAH WFRP4e v0.0.12 – v2.1.2: Core v1.5
 - TAH WFRP4e v0.0.11 and older: Core v1.4
 

--- a/dist/module.json
+++ b/dist/module.json
@@ -18,7 +18,7 @@
   "version": "<<autoreplaced>>",
   "compatibility": {
     "minimum": "12",
-    "verified": "13.342"
+    "verified": "14.360"
   },
   "relationships": {
     "systems": [
@@ -28,7 +28,7 @@
         "compatibility": [
           {
             "minimum": "8.0.0",
-            "verified": "9.0.5"
+            "verified": "9.6.1"
           }
         ]
       }
@@ -39,8 +39,8 @@
         "type": "module",
         "compatibility": [
           {
-            "minimum": "2.0.0",
-            "verified": "2.0.12"
+            "minimum": "2.1.0",
+            "verified": "2.1.1"
           }
         ]
       }

--- a/dist/modules/constants.mjs
+++ b/dist/modules/constants.mjs
@@ -2,7 +2,7 @@ const constants = {
   modulePath: 'modules/token-action-hud-wfrp4e',
   moduleId: 'token-action-hud-wfrp4e',
   moduleLabel: `Token Action HUD WFRP4e`,
-  requiredCoreModuleVersion: '2.0',
+  requiredCoreModuleVersion: '2.1',
   magicBehaviour: {
     ask: 'ask',
     cast: 'cast',


### PR DESCRIPTION
Checked the module with changes and all tested functionality works correctly.
Checked the [developer notes for 2.1](https://github.com/Larkinabout/fvtt-token-action-hud-core/wiki/Core-Changes-for-System-Module-Developers#token-action-hud-core-210) and there were no breaking changes so everything should be fine.